### PR TITLE
refactor: shorten channel and message prefix in adapter topics

### DIFF
--- a/apidocs/asyncapi/mqtt.yml
+++ b/apidocs/asyncapi/mqtt.yml
@@ -37,7 +37,7 @@ servers:
       - user-password: []
 
 channels:
-  channels/{channelID}/messages/{subtopic}:
+  ch/{channelID}/msg/{subtopic}:
     parameters:
       channelID:
         $ref: '#/components/parameters/channelID'

--- a/apidocs/asyncapi/websocket.yml
+++ b/apidocs/asyncapi/websocket.yml
@@ -32,7 +32,7 @@ servers:
         default: '8186'
 
 channels:
-  'channels/{channelID}/messages/{subtopic}':
+  'ch/{channelID}/msg/{subtopic}':
     parameters:
       channelID:
         $ref: '#/components/parameters/channelID'

--- a/apidocs/openapi/http.yml
+++ b/apidocs/openapi/http.yml
@@ -27,7 +27,7 @@ tags:
       url: https://docs.supermq.abstractmachines.fr/
 
 paths:
-  /channels/{id}/messages:
+  /ch/{id}/msg:
     post:
       summary: Sends message to the communication channel
       description: |

--- a/cli/clients_test.go
+++ b/cli/clients_test.go
@@ -221,7 +221,7 @@ func TestGetClientssCmd(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			sdkCall := sdkMock.On("Clients", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tc.page, tc.sdkErr)
-			sdkCall1 := sdkMock.On("Client", mock.Anything, mock.Anything, mock.Anything).Return(tc.client, tc.sdkErr)
+			sdkCall1 := sdkMock.On("Client", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tc.client, tc.sdkErr)
 
 			out := executeCommand(t, rootCmd, append([]string{getCmd}, tc.args...)...)
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -219,6 +219,15 @@ func main() {
 		"",
 		"Subscription contact query parameter",
 	)
+
+	rootCmd.PersistentFlags().BoolVarP(
+		&sdkConf.Roles,
+		"roles",
+		"R",
+		false,
+		"Adds option to display roles for entities",
+	)
+
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)
 	}

--- a/coap/api/transport.go
+++ b/coap/api/transport.go
@@ -33,7 +33,7 @@ const (
 	startObserve = 0 // observe option value that indicates start of observation
 )
 
-var channelPartRegExp = regexp.MustCompile(`^/channels/([\w\-]+)/messages(/[^?]*)?(\?.*)?$`)
+var channelPartRegExp = regexp.MustCompile(`^/ch/([\w\-]+)/msg(/[^?]*)?(\?.*)?$`)
 
 const (
 	numGroups    = 3 // entire expression + channel group + subtopic group

--- a/groups/api/http/decode.go
+++ b/groups/api/http/decode.go
@@ -69,9 +69,16 @@ func DecodeGroupUpdate(_ context.Context, r *http.Request) (interface{}, error) 
 }
 
 func DecodeGroupRequest(_ context.Context, r *http.Request) (interface{}, error) {
-	req := groupReq{
-		id: chi.URLParam(r, "groupID"),
+	roles, err := apiutil.ReadBoolQuery(r, api.RolesKey, false)
+	if err != nil {
+		return nil, errors.Wrap(apiutil.ErrValidation, err)
 	}
+
+	req := groupReq{
+		id:    chi.URLParam(r, "groupID"),
+		roles: roles,
+	}
+
 	return req, nil
 }
 

--- a/groups/api/http/endpoint_test.go
+++ b/groups/api/http/endpoint_test.go
@@ -236,6 +236,7 @@ func TestViewGroupEndpoint(t *testing.T) {
 		token    string
 		id       string
 		domainID string
+		roles    bool
 		session  smqauthn.Session
 		svcResp  groups.Group
 		svcErr   error
@@ -248,6 +249,7 @@ func TestViewGroupEndpoint(t *testing.T) {
 			desc:     "view group successfully",
 			token:    validToken,
 			domainID: validID,
+			roles:    false,
 			id:       validID,
 			svcResp:  validGroupResp,
 			svcErr:   nil,
@@ -260,6 +262,7 @@ func TestViewGroupEndpoint(t *testing.T) {
 			token:    invalidToken,
 			session:  smqauthn.Session{},
 			domainID: validID,
+			roles:    false,
 			id:       validID,
 			svcResp:  validGroupResp,
 			svcErr:   nil,
@@ -272,6 +275,7 @@ func TestViewGroupEndpoint(t *testing.T) {
 			token:    "",
 			session:  smqauthn.Session{},
 			domainID: validID,
+			roles:    false,
 			id:       validID,
 			status:   http.StatusUnauthorized,
 			err:      apiutil.ErrBearerToken,
@@ -288,6 +292,7 @@ func TestViewGroupEndpoint(t *testing.T) {
 			token:    validToken,
 			id:       validID,
 			domainID: validID,
+			roles:    false,
 			svcResp:  validGroupResp,
 			svcErr:   svcerr.ErrAuthorization,
 			status:   http.StatusForbidden,
@@ -300,14 +305,14 @@ func TestViewGroupEndpoint(t *testing.T) {
 			req := testRequest{
 				client: gs.Client(),
 				method: http.MethodGet,
-				url:    fmt.Sprintf("%s/%s/groups/%s", gs.URL, tc.domainID, tc.id),
+				url:    fmt.Sprintf("%s/%s/groups/%s?roles=%v", gs.URL, tc.domainID, tc.id, tc.roles),
 				token:  tc.token,
 			}
 			if tc.token == validToken {
 				tc.session = smqauthn.Session{DomainUserID: validID + "_" + validID, UserID: validID, DomainID: validID}
 			}
 			authCall := authn.On("Authenticate", mock.Anything, tc.token).Return(tc.session, tc.authnErr)
-			svcCall := svc.On("ViewGroup", mock.Anything, tc.session, tc.id).Return(tc.svcResp, tc.svcErr)
+			svcCall := svc.On("ViewGroup", mock.Anything, tc.session, tc.id, tc.roles).Return(tc.svcResp, tc.svcErr)
 			res, err := req.make()
 			assert.Nil(t, err, fmt.Sprintf("%s: unexpected error %s", tc.desc, err))
 			var errRes respBody

--- a/groups/api/http/endpoints.go
+++ b/groups/api/http/endpoints.go
@@ -48,7 +48,7 @@ func ViewGroupEndpoint(svc groups.Service) endpoint.Endpoint {
 			return viewGroupRes{}, svcerr.ErrAuthentication
 		}
 
-		group, err := svc.ViewGroup(ctx, session, req.id)
+		group, err := svc.ViewGroup(ctx, session, req.id, req.roles)
 		if err != nil {
 			return viewGroupRes{}, err
 		}

--- a/groups/api/http/requests.go
+++ b/groups/api/http/requests.go
@@ -56,7 +56,8 @@ func (req listGroupsReq) validate() error {
 }
 
 type groupReq struct {
-	id string
+	id    string
+	roles bool
 }
 
 func (req groupReq) validate() error {

--- a/groups/events/streams.go
+++ b/groups/events/streams.go
@@ -80,8 +80,8 @@ func (es eventStore) UpdateGroup(ctx context.Context, session authn.Session, gro
 	return group, nil
 }
 
-func (es eventStore) ViewGroup(ctx context.Context, session authn.Session, id string) (groups.Group, error) {
-	group, err := es.svc.ViewGroup(ctx, session, id)
+func (es eventStore) ViewGroup(ctx context.Context, session authn.Session, id string, withRoles bool) (groups.Group, error) {
+	group, err := es.svc.ViewGroup(ctx, session, id, withRoles)
 	if err != nil {
 		return group, err
 	}

--- a/groups/groups.go
+++ b/groups/groups.go
@@ -25,27 +25,29 @@ type Metadata map[string]interface{}
 // Path in a tree consisting of group IDs
 // Paths are unique per domain.
 type Group struct {
-	ID                        string    `json:"id"`
-	Domain                    string    `json:"domain_id,omitempty"`
-	Parent                    string    `json:"parent_id,omitempty"`
-	Name                      string    `json:"name"`
-	Description               string    `json:"description,omitempty"`
-	Metadata                  Metadata  `json:"metadata,omitempty"`
-	Level                     int       `json:"level,omitempty"`
-	Path                      string    `json:"path,omitempty"`
-	Children                  []*Group  `json:"children,omitempty"`
-	CreatedAt                 time.Time `json:"created_at"`
-	UpdatedAt                 time.Time `json:"updated_at,omitempty"`
-	UpdatedBy                 string    `json:"updated_by,omitempty"`
-	Status                    Status    `json:"status"`
-	RoleID                    string    `json:"role_id,omitempty"`
-	RoleName                  string    `json:"role_name,omitempty"`
-	Actions                   []string  `json:"actions,omitempty"`
-	AccessType                string    `json:"access_type,omitempty"`
-	AccessProviderId          string    `json:"access_provider_id,omitempty"`
-	AccessProviderRoleId      string    `json:"access_provider_role_id,omitempty"`
-	AccessProviderRoleName    string    `json:"access_provider_role_name,omitempty"`
-	AccessProviderRoleActions []string  `json:"access_provider_role_actions,omitempty"`
+	ID                        string                    `json:"id"`
+	Domain                    string                    `json:"domain_id,omitempty"`
+	Parent                    string                    `json:"parent_id,omitempty"`
+	Name                      string                    `json:"name"`
+	Description               string                    `json:"description,omitempty"`
+	Metadata                  Metadata                  `json:"metadata,omitempty"`
+	Level                     int                       `json:"level,omitempty"`
+	Path                      string                    `json:"path,omitempty"`
+	Children                  []*Group                  `json:"children,omitempty"`
+	CreatedAt                 time.Time                 `json:"created_at"`
+	UpdatedAt                 time.Time                 `json:"updated_at,omitempty"`
+	UpdatedBy                 string                    `json:"updated_by,omitempty"`
+	Status                    Status                    `json:"status"`
+	RoleID                    string                    `json:"role_id,omitempty"`
+	RoleName                  string                    `json:"role_name,omitempty"`
+	Actions                   []string                  `json:"actions,omitempty"`
+	AccessType                string                    `json:"access_type,omitempty"`
+	AccessProviderId          string                    `json:"access_provider_id,omitempty"`
+	AccessProviderRoleId      string                    `json:"access_provider_role_id,omitempty"`
+	AccessProviderRoleName    string                    `json:"access_provider_role_name,omitempty"`
+	AccessProviderRoleActions []string                  `json:"access_provider_role_actions,omitempty"`
+	MemberId                  string                    `json:"member_id,omitempty"`
+	Roles                     []roles.MemberRoleActions `json:"roles,omitempty"`
 }
 
 type Member struct {
@@ -96,6 +98,8 @@ type Repository interface {
 
 	RetrieveByIDAndUser(ctx context.Context, domainID, userID, groupID string) (Group, error)
 
+	RetrieveByIDWithRoles(ctx context.Context, groupID, memberID string) (Group, error)
+
 	// RetrieveAll retrieves all groups.
 	RetrieveAll(ctx context.Context, pm PageMeta) (Page, error)
 
@@ -140,7 +144,7 @@ type Service interface {
 	UpdateGroup(ctx context.Context, session authn.Session, g Group) (Group, error)
 
 	// ViewGroup retrieves data about the group identified by ID.
-	ViewGroup(ctx context.Context, session authn.Session, id string) (Group, error)
+	ViewGroup(ctx context.Context, session authn.Session, id string, withRoles bool) (Group, error)
 
 	// ListGroups retrieves groups for given filters.
 	ListGroups(ctx context.Context, session authn.Session, pm PageMeta) (Page, error)

--- a/groups/middleware/authorization.go
+++ b/groups/middleware/authorization.go
@@ -150,7 +150,7 @@ func (am *authorizationMiddleware) UpdateGroup(ctx context.Context, session auth
 	return am.svc.UpdateGroup(ctx, session, g)
 }
 
-func (am *authorizationMiddleware) ViewGroup(ctx context.Context, session authn.Session, id string) (groups.Group, error) {
+func (am *authorizationMiddleware) ViewGroup(ctx context.Context, session authn.Session, id string, withRoles bool) (groups.Group, error) {
 	if session.Type == authn.PersonalAccessToken {
 		if err := am.authz.AuthorizePAT(ctx, smqauthz.PatReq{
 			UserID:           session.UserID,
@@ -175,7 +175,7 @@ func (am *authorizationMiddleware) ViewGroup(ctx context.Context, session authn.
 		return groups.Group{}, errors.Wrap(errView, err)
 	}
 
-	return am.svc.ViewGroup(ctx, session, id)
+	return am.svc.ViewGroup(ctx, session, id, withRoles)
 }
 
 func (am *authorizationMiddleware) ListGroups(ctx context.Context, session authn.Session, gm groups.PageMeta) (groups.Page, error) {

--- a/groups/middleware/logging.go
+++ b/groups/middleware/logging.go
@@ -77,7 +77,7 @@ func (lm *loggingMiddleware) UpdateGroup(ctx context.Context, session authn.Sess
 
 // ViewGroup logs the view_group request. It logs the group name, id and the time it took to complete the request.
 // If the request fails, it logs the error.
-func (lm *loggingMiddleware) ViewGroup(ctx context.Context, session authn.Session, id string) (g groups.Group, err error) {
+func (lm *loggingMiddleware) ViewGroup(ctx context.Context, session authn.Session, id string, withRoles bool) (g groups.Group, err error) {
 	defer func(begin time.Time) {
 		args := []any{
 			slog.String("duration", time.Since(begin).String()),
@@ -86,6 +86,7 @@ func (lm *loggingMiddleware) ViewGroup(ctx context.Context, session authn.Sessio
 			slog.Group("group",
 				slog.String("id", g.ID),
 				slog.String("name", g.Name),
+				slog.Bool("with_roles", withRoles),
 			),
 		}
 		if err != nil {
@@ -95,7 +96,7 @@ func (lm *loggingMiddleware) ViewGroup(ctx context.Context, session authn.Sessio
 		}
 		lm.logger.Info("View group completed successfully", args...)
 	}(time.Now())
-	return lm.svc.ViewGroup(ctx, session, id)
+	return lm.svc.ViewGroup(ctx, session, id, withRoles)
 }
 
 // ListGroups logs the list_groups request. It logs the page metadata and the time it took to complete the request.

--- a/groups/middleware/metrics.go
+++ b/groups/middleware/metrics.go
@@ -53,12 +53,12 @@ func (ms *metricsMiddleware) UpdateGroup(ctx context.Context, session authn.Sess
 }
 
 // ViewGroup instruments ViewGroup method with metrics.
-func (ms *metricsMiddleware) ViewGroup(ctx context.Context, session authn.Session, id string) (g groups.Group, err error) {
+func (ms *metricsMiddleware) ViewGroup(ctx context.Context, session authn.Session, id string, withRoles bool) (g groups.Group, err error) {
 	defer func(begin time.Time) {
 		ms.counter.With("method", "view_group").Add(1)
 		ms.latency.With("method", "view_group").Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return ms.svc.ViewGroup(ctx, session, id)
+	return ms.svc.ViewGroup(ctx, session, id, withRoles)
 }
 
 // ListGroups instruments ListGroups method with metrics.

--- a/groups/mocks/repository.go
+++ b/groups/mocks/repository.go
@@ -334,6 +334,34 @@ func (_m *Repository) RetrieveByIDAndUser(ctx context.Context, domainID string, 
 	return r0, r1
 }
 
+// RetrieveByIDWithRoles provides a mock function with given fields: ctx, groupID, memberID
+func (_m *Repository) RetrieveByIDWithRoles(ctx context.Context, groupID string, memberID string) (groups.Group, error) {
+	ret := _m.Called(ctx, groupID, memberID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RetrieveByIDWithRoles")
+	}
+
+	var r0 groups.Group
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (groups.Group, error)); ok {
+		return rf(ctx, groupID, memberID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) groups.Group); ok {
+		r0 = rf(ctx, groupID, memberID)
+	} else {
+		r0 = ret.Get(0).(groups.Group)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, groupID, memberID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // RetrieveByIDs provides a mock function with given fields: ctx, pm, ids
 func (_m *Repository) RetrieveByIDs(ctx context.Context, pm groups.PageMeta, ids ...string) (groups.Page, error) {
 	ret := _m.Called(ctx, pm, ids)

--- a/groups/mocks/service.go
+++ b/groups/mocks/service.go
@@ -832,9 +832,9 @@ func (_m *Service) UpdateRoleName(ctx context.Context, session authn.Session, en
 	return r0, r1
 }
 
-// ViewGroup provides a mock function with given fields: ctx, session, id
-func (_m *Service) ViewGroup(ctx context.Context, session authn.Session, id string) (groups.Group, error) {
-	ret := _m.Called(ctx, session, id)
+// ViewGroup provides a mock function with given fields: ctx, session, id, withRoles
+func (_m *Service) ViewGroup(ctx context.Context, session authn.Session, id string, withRoles bool) (groups.Group, error) {
+	ret := _m.Called(ctx, session, id, withRoles)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ViewGroup")
@@ -842,17 +842,17 @@ func (_m *Service) ViewGroup(ctx context.Context, session authn.Session, id stri
 
 	var r0 groups.Group
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, authn.Session, string) (groups.Group, error)); ok {
-		return rf(ctx, session, id)
+	if rf, ok := ret.Get(0).(func(context.Context, authn.Session, string, bool) (groups.Group, error)); ok {
+		return rf(ctx, session, id, withRoles)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, authn.Session, string) groups.Group); ok {
-		r0 = rf(ctx, session, id)
+	if rf, ok := ret.Get(0).(func(context.Context, authn.Session, string, bool) groups.Group); ok {
+		r0 = rf(ctx, session, id, withRoles)
 	} else {
 		r0 = ret.Get(0).(groups.Group)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, authn.Session, string) error); ok {
-		r1 = rf(ctx, session, id)
+	if rf, ok := ret.Get(1).(func(context.Context, authn.Session, string, bool) error); ok {
+		r1 = rf(ctx, session, id, withRoles)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/groups/service.go
+++ b/groups/service.go
@@ -105,8 +105,15 @@ func (svc service) CreateGroup(ctx context.Context, session smqauthn.Session, g 
 	return saved, nrps, nil
 }
 
-func (svc service) ViewGroup(ctx context.Context, session smqauthn.Session, id string) (Group, error) {
-	group, err := svc.repo.RetrieveByIDAndUser(ctx, session.DomainID, session.UserID, id)
+func (svc service) ViewGroup(ctx context.Context, session smqauthn.Session, id string, withRoles bool) (Group, error) {
+	var group Group
+	var err error
+	switch withRoles {
+	case true:
+		group, err = svc.repo.RetrieveByIDWithRoles(ctx, id, session.UserID)
+	default:
+		group, err = svc.repo.RetrieveByID(ctx, id)
+	}
 	if err != nil {
 		return Group{}, errors.Wrap(svcerr.ErrViewEntity, err)
 	}

--- a/groups/tracing/tracing.go
+++ b/groups/tracing/tracing.go
@@ -38,11 +38,11 @@ func (tm *tracingMiddleware) CreateGroup(ctx context.Context, session authn.Sess
 }
 
 // ViewGroup traces the "ViewGroup" operation of the wrapped groups.Service.
-func (tm *tracingMiddleware) ViewGroup(ctx context.Context, session authn.Session, id string) (groups.Group, error) {
-	ctx, span := tracing.StartSpan(ctx, tm.tracer, "svc_view_group", trace.WithAttributes(attribute.String("id", id)))
+func (tm *tracingMiddleware) ViewGroup(ctx context.Context, session authn.Session, id string, withRoles bool) (groups.Group, error) {
+	ctx, span := tracing.StartSpan(ctx, tm.tracer, "svc_view_group", trace.WithAttributes(attribute.String("id", id), attribute.Bool("with_roles", withRoles)))
 	defer span.End()
 
-	return tm.svc.ViewGroup(ctx, session, id)
+	return tm.svc.ViewGroup(ctx, session, id, withRoles)
 }
 
 // ListGroups traces the "ListGroups" operation of the wrapped groups.Service.

--- a/http/api/endpoint_test.go
+++ b/http/api/endpoint_test.go
@@ -227,7 +227,7 @@ func TestPublish(t *testing.T) {
 			req := testRequest{
 				client:      ts.Client(),
 				method:      http.MethodPost,
-				url:         fmt.Sprintf("%s/channels/%s/messages", ts.URL, tc.chanID),
+				url:         fmt.Sprintf("%s/ch/%s/msg", ts.URL, tc.chanID),
 				contentType: tc.contentType,
 				token:       tc.key,
 				body:        strings.NewReader(tc.msg),

--- a/http/api/transport.go
+++ b/http/api/transport.go
@@ -33,14 +33,14 @@ func MakeHandler(logger *slog.Logger, instanceID string) http.Handler {
 	}
 
 	r := chi.NewRouter()
-	r.Post("/channels/{chanID}/messages", otelhttp.NewHandler(kithttp.NewServer(
+	r.Post("/ch/{chanID}/msg", otelhttp.NewHandler(kithttp.NewServer(
 		sendMessageEndpoint(),
 		decodeRequest,
 		api.EncodeResponse,
 		opts...,
 	), "publish").ServeHTTP)
 
-	r.Post("/channels/{chanID}/messages/*", otelhttp.NewHandler(kithttp.NewServer(
+	r.Post("/ch/{chanID}/msg/*", otelhttp.NewHandler(kithttp.NewServer(
 		sendMessageEndpoint(),
 		decodeRequest,
 		api.EncodeResponse,

--- a/http/handler.go
+++ b/http/handler.go
@@ -55,7 +55,7 @@ var (
 	errFailedParseSubtopic      = mgate.NewHTTPProxyError(http.StatusBadRequest, errors.New("failed to parse subtopic"))
 )
 
-var channelRegExp = regexp.MustCompile(`^\/?channels\/([\w\-]+)\/messages(\/[^?]*)?(\?.*)?$`)
+var channelRegExp = regexp.MustCompile(`^\/?ch\/([\w\-]+)\/msg(\/[^?]*)?(\?.*)?$`)
 
 // Event implements events.Event interface.
 type handler struct {
@@ -210,7 +210,7 @@ func (h *handler) Disconnect(ctx context.Context) error {
 
 func parseTopic(topic string) (string, string, error) {
 	// Topics are in the format:
-	// channels/<channel_id>/messages/<subtopic>/.../ct/<content_type>
+	// ch/<channel_id>/msg/<subtopic>/.../ct/<content_type>
 	channelParts := channelRegExp.FindStringSubmatch(topic)
 	if len(channelParts) < 2 {
 		return "", "", errors.Wrap(errFailedPublish, errMalformedTopic)

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -39,8 +39,8 @@ const (
 )
 
 var (
-	topicMsg      = "channels/%s/messages"
-	subtopicMsg   = "channels/%s/messages/subtopic"
+	topicMsg      = "ch/%s/msg"
+	subtopicMsg   = "ch/%s/msg/subtopic"
 	topic         = fmt.Sprintf(topicMsg, chanID)
 	subtopic      = fmt.Sprintf(subtopicMsg, chanID)
 	invalidTopic  = invalidValue

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -35,7 +35,7 @@ const (
 	chanID                = "123e4567-e89b-12d3-a456-000000000001"
 	invalidID             = "invalidID"
 	invalidValue          = "invalidValue"
-	invalidChannelIDTopic = "channels/**/messages"
+	invalidChannelIDTopic = "ch/**/msg"
 )
 
 var (

--- a/mqtt/events/streams.go
+++ b/mqtt/events/streams.go
@@ -20,7 +20,7 @@ const streamID = "supermq.mqtt"
 var (
 	errFailedSession  = errors.New("failed to obtain session from context")
 	errMalformedTopic = errors.New("malformed topic")
-	channelRegExp     = regexp.MustCompile(`^\/?channels\/([\w\-]+)\/messages(\/[^?]*)?(\?.*)?$`)
+	channelRegExp     = regexp.MustCompile(`^\/?ch\/([\w\-]+)\/msg(\/[^?]*)?(\?.*)?$`)
 )
 
 // EventStore is a struct used to store event streams in Redis.

--- a/mqtt/forwarder.go
+++ b/mqtt/forwarder.go
@@ -49,7 +49,7 @@ func handle(ctx context.Context, pub messaging.Publisher, logger *slog.Logger) h
 		}
 		// Use concatenation instead of fmt.Sprintf for the
 		// sake of simplicity and performance.
-		topic := "channels/" + msg.GetChannel() + "/messages"
+		topic := "ch/" + msg.GetChannel() + "/msg"
 		if msg.GetSubtopic() != "" {
 			topic = topic + "/" + strings.ReplaceAll(msg.GetSubtopic(), ".", "/")
 		}

--- a/mqtt/handler.go
+++ b/mqtt/handler.go
@@ -57,7 +57,7 @@ var (
 
 var (
 	errInvalidUserId = errors.New("invalid user id")
-	channelRegExp    = regexp.MustCompile(`^\/?channels\/([\w\-]+)\/messages(\/[^?]*)?(\?.*)?$`)
+	channelRegExp    = regexp.MustCompile(`^\/?ch\/([\w\-]+)\/msg(\/[^?]*)?(\?.*)?$`)
 )
 
 // Event implements events.Event interface.
@@ -159,7 +159,7 @@ func (h *handler) Publish(ctx context.Context, topic *string, payload *[]byte) e
 	}
 	h.logger.Info(fmt.Sprintf(LogInfoPublished, s.ID, *topic))
 	// Topics are in the format:
-	// channels/<channel_id>/messages/<subtopic>/.../ct/<content_type>
+	// ch/<channel_id>/msg/<subtopic>/.../ct/<content_type>
 
 	channelParts := channelRegExp.FindStringSubmatch(*topic)
 	if len(channelParts) < 2 {
@@ -225,7 +225,7 @@ func (h *handler) Disconnect(ctx context.Context) error {
 
 func (h *handler) authAccess(ctx context.Context, clientID, topic string, msgType connections.ConnType) error {
 	// Topics are in the format:
-	// channels/<channel_id>/messages/<subtopic>/.../ct/<content_type>
+	// ch/<channel_id>/msg/<subtopic>/.../ct/<content_type>
 	if !channelRegExp.MatchString(topic) {
 		return ErrMalformedTopic
 	}

--- a/mqtt/handler_test.go
+++ b/mqtt/handler_test.go
@@ -36,11 +36,11 @@ const (
 	clientID              = "clientID"
 	clientID1             = "clientID1"
 	subtopic              = "testSubtopic"
-	invalidChannelIDTopic = "channels/**/messages"
+	invalidChannelIDTopic = "ch/**/msg"
 )
 
 var (
-	topicMsg            = "channels/%s/messages"
+	topicMsg            = "ch/%s/msg"
 	topic               = fmt.Sprintf(topicMsg, chanID)
 	invalidTopic        = invalidValue
 	payload             = []byte("[{'n':'test-name', 'v': 1.2}]")

--- a/pkg/sdk/channels.go
+++ b/pkg/sdk/channels.go
@@ -11,6 +11,7 @@ import (
 
 	apiutil "github.com/absmach/supermq/api/http/util"
 	"github.com/absmach/supermq/pkg/errors"
+	"github.com/absmach/supermq/pkg/roles"
 )
 
 const (
@@ -20,17 +21,18 @@ const (
 
 // Channel represents supermq channel.
 type Channel struct {
-	ID          string    `json:"id,omitempty"`
-	Name        string    `json:"name,omitempty"`
-	Tags        []string  `json:"tags,omitempty"`
-	ParentGroup string    `json:"parent_group_id,omitempty"`
-	DomainID    string    `json:"domain_id,omitempty"`
-	Metadata    Metadata  `json:"metadata,omitempty"`
-	CreatedAt   time.Time `json:"created_at,omitempty"`
-	UpdatedAt   time.Time `json:"updated_at,omitempty"`
-	UpdatedBy   string    `json:"updated_by,omitempty"`
-	Status      string    `json:"status,omitempty"`
-	Permissions []string  `json:"permissions,omitempty"`
+	ID          string                    `json:"id,omitempty"`
+	Name        string                    `json:"name,omitempty"`
+	Tags        []string                  `json:"tags,omitempty"`
+	ParentGroup string                    `json:"parent_group_id,omitempty"`
+	DomainID    string                    `json:"domain_id,omitempty"`
+	Metadata    Metadata                  `json:"metadata,omitempty"`
+	CreatedAt   time.Time                 `json:"created_at,omitempty"`
+	UpdatedAt   time.Time                 `json:"updated_at,omitempty"`
+	UpdatedBy   string                    `json:"updated_by,omitempty"`
+	Status      string                    `json:"status,omitempty"`
+	Permissions []string                  `json:"permissions,omitempty"`
+	Roles       []roles.MemberRoleActions `json:"roles,omitempty"`
 }
 
 func (sdk mgSDK) CreateChannel(c Channel, domainID, token string) (Channel, errors.SDKError) {

--- a/pkg/sdk/clients.go
+++ b/pkg/sdk/clients.go
@@ -11,6 +11,7 @@ import (
 
 	apiutil "github.com/absmach/supermq/api/http/util"
 	"github.com/absmach/supermq/pkg/errors"
+	"github.com/absmach/supermq/pkg/roles"
 )
 
 const (
@@ -25,18 +26,19 @@ const (
 
 // Client represents supermq client.
 type Client struct {
-	ID          string                 `json:"id,omitempty"`
-	Name        string                 `json:"name,omitempty"`
-	Tags        []string               `json:"tags,omitempty"`
-	DomainID    string                 `json:"domain_id,omitempty"`
-	ParentGroup string                 `json:"parent_group_id,omitempty"`
-	Credentials ClientCredentials      `json:"credentials"`
-	Metadata    map[string]interface{} `json:"metadata,omitempty"`
-	CreatedAt   time.Time              `json:"created_at,omitempty"`
-	UpdatedAt   time.Time              `json:"updated_at,omitempty"`
-	UpdatedBy   string                 `json:"updated_by,omitempty"`
-	Status      string                 `json:"status,omitempty"`
-	Permissions []string               `json:"permissions,omitempty"`
+	ID          string                    `json:"id,omitempty"`
+	Name        string                    `json:"name,omitempty"`
+	Tags        []string                  `json:"tags,omitempty"`
+	DomainID    string                    `json:"domain_id,omitempty"`
+	ParentGroup string                    `json:"parent_group_id,omitempty"`
+	Credentials ClientCredentials         `json:"credentials"`
+	Metadata    map[string]interface{}    `json:"metadata,omitempty"`
+	CreatedAt   time.Time                 `json:"created_at,omitempty"`
+	UpdatedAt   time.Time                 `json:"updated_at,omitempty"`
+	UpdatedBy   string                    `json:"updated_by,omitempty"`
+	Status      string                    `json:"status,omitempty"`
+	Permissions []string                  `json:"permissions,omitempty"`
+	Roles       []roles.MemberRoleActions `json:"roles,omitempty"`
 }
 
 type ClientCredentials struct {

--- a/pkg/sdk/domains_test.go
+++ b/pkg/sdk/domains_test.go
@@ -345,6 +345,12 @@ func TestViewDomain(t *testing.T) {
 
 	mgsdk := sdk.NewSDK(sdkConf)
 
+	sdkConfRoles := sdk.Config{
+		DomainsURL: ds.URL,
+		Roles:      true,
+	}
+	mgsdkRoles := sdk.NewSDK(sdkConfRoles)
+
 	cases := []struct {
 		desc      string
 		token     string
@@ -371,7 +377,7 @@ func TestViewDomain(t *testing.T) {
 			desc:      "view domain successfully with roles",
 			token:     validToken,
 			domainID:  sdkDomain.ID,
-			withRoles: false,
+			withRoles: true,
 			svcRes:    authDomain,
 			svcErr:    nil,
 			response:  sdkDomain,
@@ -441,7 +447,16 @@ func TestViewDomain(t *testing.T) {
 			}
 			authCall := authn.On("Authenticate", mock.Anything, mock.Anything).Return(tc.session, tc.authnErr)
 			svcCall := svc.On("RetrieveDomain", mock.Anything, tc.session, tc.domainID, tc.withRoles).Return(tc.svcRes, tc.svcErr)
-			resp, err := mgsdk.Domain(tc.domainID, tc.token)
+
+			var resp sdk.Domain
+			var err error
+
+			switch tc.withRoles {
+			case true:
+				resp, err = mgsdkRoles.Domain(tc.domainID, tc.token)
+			default:
+				resp, err = mgsdk.Domain(tc.domainID, tc.token)
+			}
 			assert.Equal(t, tc.err, err)
 			assert.Equal(t, tc.response, resp)
 			if tc.withRoles {
@@ -2332,6 +2347,7 @@ func generateTestDomain(t *testing.T) (domains.Domain, sdk.Domain) {
 		CreatedAt: createdAt,
 		UpdatedBy: ownerID,
 		UpdatedAt: createdAt,
+		Roles:     validRoles,
 	}
 
 	sd := sdk.Domain{
@@ -2345,6 +2361,7 @@ func generateTestDomain(t *testing.T) (domains.Domain, sdk.Domain) {
 		CreatedAt: ad.CreatedAt,
 		UpdatedBy: ad.UpdatedBy,
 		UpdatedAt: ad.UpdatedAt,
+		Roles:     ad.Roles,
 	}
 	return ad, sd
 }

--- a/pkg/sdk/groups.go
+++ b/pkg/sdk/groups.go
@@ -11,6 +11,7 @@ import (
 
 	apiutil "github.com/absmach/supermq/api/http/util"
 	"github.com/absmach/supermq/pkg/errors"
+	"github.com/absmach/supermq/pkg/roles"
 )
 
 const (
@@ -25,27 +26,28 @@ const (
 // Path in a tree consisting of group IDs
 // Paths are unique per owner.
 type Group struct {
-	ID                        string    `json:"id,omitempty"`
-	DomainID                  string    `json:"domain_id,omitempty"`
-	ParentID                  string    `json:"parent_id,omitempty"`
-	Name                      string    `json:"name,omitempty"`
-	Description               string    `json:"description,omitempty"`
-	Metadata                  Metadata  `json:"metadata,omitempty"`
-	Level                     int       `json:"level,omitempty"`
-	Path                      string    `json:"path,omitempty"`
-	Children                  []*Group  `json:"children,omitempty"`
-	CreatedAt                 time.Time `json:"created_at,omitempty"`
-	UpdatedAt                 time.Time `json:"updated_at,omitempty"`
-	UpdatedBy                 string    `json:"updated_by,omitempty"`
-	Status                    string    `json:"status,omitempty"`
-	RoleID                    string    `json:"role_id,omitempty"`
-	RoleName                  string    `json:"role_name,omitempty"`
-	Actions                   []string  `json:"actions,omitempty"`
-	AccessType                string    `json:"access_type,omitempty"`
-	AccessProviderId          string    `json:"access_provider_id,omitempty"`
-	AccessProviderRoleId      string    `json:"access_provider_role_id,omitempty"`
-	AccessProviderRoleName    string    `json:"access_provider_role_name,omitempty"`
-	AccessProviderRoleActions []string  `json:"access_provider_role_actions,omitempty"`
+	ID                        string                    `json:"id,omitempty"`
+	DomainID                  string                    `json:"domain_id,omitempty"`
+	ParentID                  string                    `json:"parent_id,omitempty"`
+	Name                      string                    `json:"name,omitempty"`
+	Description               string                    `json:"description,omitempty"`
+	Metadata                  Metadata                  `json:"metadata,omitempty"`
+	Level                     int                       `json:"level,omitempty"`
+	Path                      string                    `json:"path,omitempty"`
+	Children                  []*Group                  `json:"children,omitempty"`
+	CreatedAt                 time.Time                 `json:"created_at,omitempty"`
+	UpdatedAt                 time.Time                 `json:"updated_at,omitempty"`
+	UpdatedBy                 string                    `json:"updated_by,omitempty"`
+	Status                    string                    `json:"status,omitempty"`
+	RoleID                    string                    `json:"role_id,omitempty"`
+	RoleName                  string                    `json:"role_name,omitempty"`
+	Actions                   []string                  `json:"actions,omitempty"`
+	AccessType                string                    `json:"access_type,omitempty"`
+	AccessProviderId          string                    `json:"access_provider_id,omitempty"`
+	AccessProviderRoleId      string                    `json:"access_provider_role_id,omitempty"`
+	AccessProviderRoleName    string                    `json:"access_provider_role_name,omitempty"`
+	AccessProviderRoleActions []string                  `json:"access_provider_role_actions,omitempty"`
+	Roles                     []roles.MemberRoleActions `json:"roles,omitempty"`
 }
 
 func (sdk mgSDK) CreateGroup(g Group, domainID, token string) (Group, errors.SDKError) {

--- a/pkg/sdk/groups_test.go
+++ b/pkg/sdk/groups_test.go
@@ -523,11 +523,18 @@ func TestViewGroup(t *testing.T) {
 	}
 	mgsdk := sdk.NewSDK(conf)
 
+	confRoles := sdk.Config{
+		GroupsURL: ts.URL,
+		Roles:     true,
+	}
+	mgsdkRoles := sdk.NewSDK(confRoles)
+
 	cases := []struct {
 		desc            string
 		domainID        string
 		token           string
 		session         smqauthn.Session
+		withRoles       bool
 		groupID         string
 		svcRes          groups.Group
 		svcErr          error
@@ -536,19 +543,32 @@ func TestViewGroup(t *testing.T) {
 		err             errors.SDKError
 	}{
 		{
-			desc:     "view group successfully",
-			domainID: domainID,
-			token:    validToken,
-			groupID:  group.ID,
-			svcRes:   group,
-			svcErr:   nil,
-			response: sdkGroup,
-			err:      nil,
+			desc:      "view group successfully",
+			domainID:  domainID,
+			token:     validToken,
+			withRoles: false,
+			groupID:   group.ID,
+			svcRes:    group,
+			svcErr:    nil,
+			response:  sdkGroup,
+			err:       nil,
+		},
+		{
+			desc:      "view group successfully with roles",
+			domainID:  domainID,
+			token:     validToken,
+			withRoles: true,
+			groupID:   group.ID,
+			svcRes:    group,
+			svcErr:    nil,
+			response:  sdkGroup,
+			err:       nil,
 		},
 		{
 			desc:            "view group with invalid token",
 			domainID:        domainID,
 			token:           invalidToken,
+			withRoles:       false,
 			groupID:         group.ID,
 			svcRes:          groups.Group{},
 			authenticateErr: svcerr.ErrAuthentication,
@@ -556,30 +576,33 @@ func TestViewGroup(t *testing.T) {
 			err:             errors.NewSDKErrorWithStatus(svcerr.ErrAuthentication, http.StatusUnauthorized),
 		},
 		{
-			desc:     "view group with empty token",
-			domainID: domainID,
-			token:    "",
-			groupID:  group.ID,
-			svcRes:   groups.Group{},
-			svcErr:   nil,
-			response: sdk.Group{},
-			err:      errors.NewSDKErrorWithStatus(apiutil.ErrBearerToken, http.StatusUnauthorized),
+			desc:      "view group with empty token",
+			domainID:  domainID,
+			token:     "",
+			withRoles: false,
+			groupID:   group.ID,
+			svcRes:    groups.Group{},
+			svcErr:    nil,
+			response:  sdk.Group{},
+			err:       errors.NewSDKErrorWithStatus(apiutil.ErrBearerToken, http.StatusUnauthorized),
 		},
 		{
-			desc:     "view group with invalid group id",
-			domainID: domainID,
-			token:    validToken,
-			groupID:  wrongID,
-			svcRes:   groups.Group{},
-			svcErr:   svcerr.ErrViewEntity,
-			response: sdk.Group{},
-			err:      errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
+			desc:      "view group with invalid group id",
+			domainID:  domainID,
+			token:     validToken,
+			withRoles: false,
+			groupID:   wrongID,
+			svcRes:    groups.Group{},
+			svcErr:    svcerr.ErrViewEntity,
+			response:  sdk.Group{},
+			err:       errors.NewSDKErrorWithStatus(svcerr.ErrViewEntity, http.StatusBadRequest),
 		},
 		{
-			desc:     "view group with service response that cannot be unmarshalled",
-			domainID: domainID,
-			token:    validToken,
-			groupID:  group.ID,
+			desc:      "view group with service response that cannot be unmarshalled",
+			domainID:  domainID,
+			token:     validToken,
+			withRoles: false,
+			groupID:   group.ID,
 			svcRes: groups.Group{
 				ID:   group.ID,
 				Name: "group_1",
@@ -592,14 +615,15 @@ func TestViewGroup(t *testing.T) {
 			err:      errors.NewSDKError(errors.New("unexpected end of JSON input")),
 		},
 		{
-			desc:     "view group with empty id",
-			domainID: domainID,
-			token:    validToken,
-			groupID:  "",
-			svcRes:   groups.Group{},
-			svcErr:   nil,
-			response: sdk.Group{},
-			err:      errors.NewSDKError(apiutil.ErrMissingID),
+			desc:      "view group with empty id",
+			domainID:  domainID,
+			token:     validToken,
+			withRoles: false,
+			groupID:   "",
+			svcRes:    groups.Group{},
+			svcErr:    nil,
+			response:  sdk.Group{},
+			err:       errors.NewSDKError(apiutil.ErrMissingID),
 		},
 	}
 
@@ -609,12 +633,25 @@ func TestViewGroup(t *testing.T) {
 				tc.session = smqauthn.Session{DomainUserID: domainID + "_" + validID, UserID: validID, DomainID: domainID}
 			}
 			authCall := auth.On("Authenticate", mock.Anything, tc.token).Return(tc.session, tc.authenticateErr)
-			svcCall := gsvc.On("ViewGroup", mock.Anything, tc.session, tc.groupID).Return(tc.svcRes, tc.svcErr)
-			resp, err := mgsdk.Group(tc.groupID, tc.domainID, tc.token)
+			svcCall := gsvc.On("ViewGroup", mock.Anything, tc.session, tc.groupID, tc.withRoles).Return(tc.svcRes, tc.svcErr)
+
+			var resp sdk.Group
+			var err error
+
+			switch tc.withRoles {
+			case true:
+				resp, err = mgsdkRoles.Group(tc.groupID, tc.domainID, tc.token)
+			default:
+				resp, err = mgsdk.Group(tc.groupID, tc.domainID, tc.token)
+			}
+
 			assert.Equal(t, tc.err, err)
 			assert.Equal(t, tc.response, resp)
+			if tc.withRoles {
+				assert.Equal(t, resp.Roles, validRoles, fmt.Sprintf("%s: expected %v got %v\n", tc.desc, validRoles, resp.Roles))
+			}
 			if tc.err == nil {
-				ok := svcCall.Parent.AssertCalled(t, "ViewGroup", mock.Anything, tc.session, tc.groupID)
+				ok := svcCall.Parent.AssertCalled(t, "ViewGroup", mock.Anything, tc.session, tc.groupID, tc.withRoles)
 				assert.True(t, ok)
 			}
 			svcCall.Unset()
@@ -3631,6 +3668,7 @@ func generateTestGroup(t *testing.T) sdk.Group {
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
 		Status:      groups.EnabledStatus.String(),
+		Roles:       validRoles,
 	}
 	return gr
 }

--- a/pkg/sdk/message.go
+++ b/pkg/sdk/message.go
@@ -22,7 +22,7 @@ func (sdk mgSDK) SendMessage(chanName, msg, key string) errors.SDKError {
 		subtopicPart = fmt.Sprintf("/%s", strings.ReplaceAll(chanNameParts[1], ".", "/"))
 	}
 
-	reqURL := fmt.Sprintf("%s/channels/%s/messages%s", sdk.httpAdapterURL, chanID, subtopicPart)
+	reqURL := fmt.Sprintf("%s/ch/%s/msg%s", sdk.httpAdapterURL, chanID, subtopicPart)
 
 	_, _, err := sdk.processRequest(http.MethodPost, reqURL, ClientPrefix+key, []byte(msg), nil, http.StatusAccepted)
 

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -1324,6 +1324,7 @@ type mgSDK struct {
 	msgContentType ContentType
 	client         *http.Client
 	curlFlag       bool
+	roles          bool
 }
 
 // Config contains sdk configuration parameters.
@@ -1341,6 +1342,7 @@ type Config struct {
 	MsgContentType  ContentType
 	TLSVerification bool
 	CurlFlag        bool
+	Roles           bool
 }
 
 // NewSDK returns new supermq SDK instance.
@@ -1365,12 +1367,16 @@ func NewSDK(conf Config) SDK {
 			},
 		},
 		curlFlag: conf.CurlFlag,
+		roles:    conf.Roles,
 	}
 }
 
 // processRequest creates and send a new HTTP request, and checks for errors in the HTTP response.
 // It then returns the response headers, the response body, and the associated error(s) (if any).
 func (sdk mgSDK) processRequest(method, reqUrl, token string, data []byte, headers map[string]string, expectedRespCodes ...int) (http.Header, []byte, errors.SDKError) {
+	if sdk.roles {
+		reqUrl = reqUrl + fmt.Sprintf("?roles=%v", true)
+	}
 	req, err := http.NewRequest(method, reqUrl, bytes.NewReader(data))
 	if err != nil {
 		return make(http.Header), []byte{}, errors.NewSDKError(err)

--- a/pkg/sdk/setup_test.go
+++ b/pkg/sdk/setup_test.go
@@ -128,6 +128,7 @@ func convertGroup(g sdk.Group) groups.Group {
 		AccessProviderRoleId:      g.AccessProviderRoleId,
 		AccessProviderRoleName:    g.AccessProviderRoleName,
 		AccessProviderRoleActions: g.AccessProviderRoleActions,
+		Roles:                     g.Roles,
 	}
 }
 
@@ -194,6 +195,7 @@ func convertClient(c sdk.Client) clients.Client {
 		UpdatedAt:   c.UpdatedAt,
 		UpdatedBy:   c.UpdatedBy,
 		Status:      status,
+		Roles:       c.Roles,
 	}
 }
 
@@ -216,6 +218,7 @@ func convertChannel(g sdk.Channel) mgchannels.Channel {
 		UpdatedAt:   g.UpdatedAt,
 		UpdatedBy:   g.UpdatedBy,
 		Status:      status,
+		Roles:       g.Roles,
 	}
 }
 

--- a/ws/api/endpoint_test.go
+++ b/ws/api/endpoint_test.go
@@ -65,9 +65,9 @@ func makeURL(tsURL, chanID, subtopic, clientKey string, header bool) (string, er
 
 	if chanID == "0" || chanID == "" {
 		if header {
-			return fmt.Sprintf("%s/channels/%s/messages", u, chanID), fmt.Errorf("invalid channel id")
+			return fmt.Sprintf("%s/ch/%s/msg", u, chanID), fmt.Errorf("invalid channel id")
 		}
-		return fmt.Sprintf("%s/channels/%s/messages?authorization=%s", u, chanID, clientKey), fmt.Errorf("invalid channel id")
+		return fmt.Sprintf("%s/ch/%s/msg?authorization=%s", u, chanID, clientKey), fmt.Errorf("invalid channel id")
 	}
 
 	subtopicPart := ""
@@ -75,10 +75,10 @@ func makeURL(tsURL, chanID, subtopic, clientKey string, header bool) (string, er
 		subtopicPart = fmt.Sprintf("/%s", subtopic)
 	}
 	if header {
-		return fmt.Sprintf("%s/channels/%s/messages%s", u, chanID, subtopicPart), nil
+		return fmt.Sprintf("%s/ch/%s/msg%s", u, chanID, subtopicPart), nil
 	}
 
-	return fmt.Sprintf("%s/channels/%s/messages%s?authorization=%s", u, chanID, subtopicPart, clientKey), nil
+	return fmt.Sprintf("%s/ch/%s/msg%s?authorization=%s", u, chanID, subtopicPart, clientKey), nil
 }
 
 func handshake(tsURL, chanID, subtopic, clientKey string, addHeader bool) (*websocket.Conn, *http.Response, error) {

--- a/ws/api/endpoints.go
+++ b/ws/api/endpoints.go
@@ -16,7 +16,7 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-var channelPartRegExp = regexp.MustCompile(`^/channels/([\w\-]+)/messages(/[^?]*)?(\?.*)?$`)
+var channelPartRegExp = regexp.MustCompile(`^/ch/([\w\-]+)/msg(/[^?]*)?(\?.*)?$`)
 
 func handshake(ctx context.Context, svc ws.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/ws/api/transport.go
+++ b/ws/api/transport.go
@@ -40,8 +40,8 @@ func MakeHandler(ctx context.Context, svc ws.Service, l *slog.Logger, instanceID
 	logger = l
 
 	mux := chi.NewRouter()
-	mux.Get("/channels/{chanID}/messages", handshake(ctx, svc))
-	mux.Get("/channels/{chanID}/messages/*", handshake(ctx, svc))
+	mux.Get("/ch/{chanID}/msg", handshake(ctx, svc))
+	mux.Get("/ch/{chanID}/msg/*", handshake(ctx, svc))
 
 	mux.Get("/health", supermq.Health(service, instanceID))
 	mux.Handle("/metrics", promhttp.Handler())

--- a/ws/handler.go
+++ b/ws/handler.go
@@ -50,7 +50,7 @@ var (
 	errFailedPublishToMsgBroker = errors.New("failed to publish to supermq message broker")
 )
 
-var channelRegExp = regexp.MustCompile(`^\/?channels\/([\w\-]+)\/messages(\/[^?]*)?(\?.*)?$`)
+var channelRegExp = regexp.MustCompile(`^\/?ch\/([\w\-]+)\/msg(\/[^?]*)?(\?.*)?$`)
 
 // Event implements events.Event interface.
 type handler struct {

--- a/ws/handler.go
+++ b/ws/handler.go
@@ -139,7 +139,7 @@ func (h *handler) Publish(ctx context.Context, topic *string, payload *[]byte) e
 	}
 
 	// Topics are in the format:
-	// channels/<channel_id>/messages/<subtopic>/.../ct/<content_type>
+	// ch/<channel_id>/msg/<subtopic>/.../ct/<content_type>
 	channelParts := channelRegExp.FindStringSubmatch(*topic)
 	if len(channelParts) < 2 {
 		return errors.Wrap(errFailedPublish, errMalformedTopic)
@@ -224,7 +224,7 @@ func (h *handler) authAccess(ctx context.Context, token, topic string, msgType c
 	clientID := authnRes.GetId()
 
 	// Topics are in the format:
-	// channels/<channel_id>/messages/<subtopic>/.../ct/<content_type>
+	// ch/<channel_id>/msg/<subtopic>/.../ct/<content_type>
 	if !channelRegExp.MatchString(topic) {
 		return "", "", errMalformedTopic
 	}


### PR DESCRIPTION
<!-- Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0 -->

<!--

Pull request title should be `SMQ-XXX - description` or `NOISSUE - description` where XXX is ID of the issue that this PR relate to.
Please review the [CONTRIBUTING.md](https://github.com/absmach/supermq/blob/main/CONTRIBUTING.md) file for detailed contributing guidelines.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

- Provide tests for your changes.
- Use descriptive commit messages.
- Comment your code where appropriate.
- Squash your commits
- Update any related documentation.
-->

# What type of PR is this?

<!--This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?

<!--
Please provide a brief description of what this PR is intended to do.
Include List any changes that modify/break current functionality.
-->

## Which issue(s) does this PR fix/relate to?

<!--
For pull requests that relate or close an issue, please include them below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "Resolves #1234" would connect the current pull request to issue 1234.  And when we merge the pull request, Github will automatically close the issue.
-->

- Related Issue #
- Resolves #

## Have you included tests for your changes?

<!--If you have not included tests, please explain why.
For example:
Yes, I have included tests for my changes.
No, I have not included tests because I do not know how to.
-->

## Did you document any new/modified feature?

<!--If you have not included documentation, please explain why.
For example:
Yes, I have updated the documentation for the new feature.
No, I have not updated the documentation because I do not know how to.
-->

### Notes

<!--Please provide any additional information you feel is important.-->

## Summary by Sourcery

Refactors the adapter topics to shorten the channel and message prefix from `/channels/{chanID}/messages` to `/ch/{chanID}/msg`. This change affects the HTTP, MQTT, and WebSocket adapters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated API endpoint URLs for channel messaging by replacing longer path segments with concise identifiers, streamlining how requests are handled.
  - Enhanced the `ViewGroup` method to include role information retrieval, improving the flexibility of group data access.

- **Tests**
  - Adjusted test cases across various protocols to validate the new endpoint structure and incorporate role-related scenarios.

- **Documentation**
  - Updated AsyncAPI and OpenAPI specifications to reflect the new, simplified channel and message path formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->